### PR TITLE
[FIX] #39 Delete package.json "homepage" property

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "homepage": "http://3.35.14.180/meeting"
+  }
 }


### PR DESCRIPTION
"homepage" : "http://3.35.14.180/meeting" 추가하여 배포한 결과, 에러 발생하여 일단 삭제 합니다.

"homepage" 프로퍼티에 관련하여 알아본 후, 에러 발생 이유에 대한 내용을 이슈에 올리겠습니다.