### PR TITLE
[FIX] #27 Add "withCredentials: true" to axios.get request

### DIFF
--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -5,7 +5,9 @@ const Login = () => {
   const handleLogin = async () => {
     try {
       // window.location.href = '/meeting/reservation';
-      const response = await axios.get('http://15.164.85.227:8080/login');
+      const response = await axios.get('http://15.164.85.227:8080/login', {
+        withCredentials: true,
+      });
       // const response = await axios.get('http://15.164.85.227:8080/member/login');
       console.log(response.headers);
     } catch (err) {


### PR DESCRIPTION
CORS 에러 해결을 위해 로그인 GET 요청 헤더에 {withCredentials: true} 를 추가했습니다.